### PR TITLE
Fix logic to keep settings and preference dialog widgets in sync (`dask`, `highlight`, `brush_size_on_mouse_move_modifiers`, `new_labels_dtype` settings errors)

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -1184,3 +1184,26 @@ def test_scale_bar_ticks(qt_viewer, qtbot):
 
     scale_bar.ticks = True
     qtbot.waitUntil(check_ticks_scale_bar)
+
+
+@skip_local_popups
+def test_dask_cache(qt_viewer):
+    initial_dask_cache = get_settings().application.dask.cache
+
+    # check that disabling dask cache setting calls related logic
+    with mock.patch(
+        'napari._qt.qt_viewer.resize_dask_cache'
+    ) as mock_resize_dask_cache:
+        get_settings().application.dask.enabled = False
+    mock_resize_dask_cache.assert_called_once_with(
+        int(int(False) * initial_dask_cache * 1e9)
+    )
+
+    # check that enabling dask cache setting calls related logic
+    with mock.patch(
+        'napari._qt.qt_viewer.resize_dask_cache'
+    ) as mock_resize_dask_cache:
+        get_settings().application.dask.enabled = True
+    mock_resize_dask_cache.assert_called_once_with(
+        int(int(True) * initial_dask_cache * 1e9)
+    )

--- a/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -1,5 +1,6 @@
 import sys
 
+import numpy.testing as npt
 import pytest
 from qtpy.QtCore import Qt
 
@@ -9,10 +10,13 @@ from napari._qt.dialogs.preferences_dialog import (
     QMessageBox,
 )
 from napari._vendor.qt_json_builder.qt_jsonschema_form.widgets import (
+    EnumSchemaWidget,
     FontSizeSchemaWidget,
+    HighlightPreviewWidget,
     HorizontalObjectSchemaWidget,
 )
 from napari.settings import NapariSettings, get_settings
+from napari.settings._constants import BrushSizeOnMouseModifiers, LabelDTypes
 
 
 @pytest.fixture()
@@ -23,6 +27,8 @@ def pref(qtbot):
     assert settings.appearance.theme == 'dark'
     dlg._settings.appearance.theme = 'light'
     assert get_settings().appearance.theme == 'light'
+    dlg._settings.appearance.highlight.highlight_thickness = 5
+    assert get_settings().appearance.highlight.highlight_thickness == 5
     return dlg
 
 
@@ -35,10 +41,29 @@ def test_prefdialog_populated(pref):
 
 
 def test_dask_widget(qtbot, pref):
-    assert isinstance(
-        pref._stack.currentWidget().widget().widget.widgets['dask'],
-        HorizontalObjectSchemaWidget,
-    )
+    dask_widget = pref._stack.currentWidget().widget().widget.widgets['dask']
+    def_dask_enabled = True
+    settings = pref._settings
+
+    # check custom widget definition and default value for dask cache `enabled` setting
+    assert isinstance(dask_widget, HorizontalObjectSchemaWidget)
+    assert settings.application.dask.enabled == def_dask_enabled
+    assert dask_widget.state['enabled'] == def_dask_enabled
+
+    # check changing dask cache `enabled` setting via widget
+    new_dask_enabled = False
+    dask_widget.state = {
+        'enabled': new_dask_enabled,
+        'cache': dask_widget.state['cache'],
+    }
+    assert settings.application.dask.enabled == new_dask_enabled
+    assert dask_widget.state['enabled'] == new_dask_enabled
+    assert dask_widget.widgets['enabled'].state == new_dask_enabled
+
+    # check changing dask `enabled` setting via settings object (to default value)
+    settings.application.dask.enabled = def_dask_enabled
+    assert dask_widget.state['enabled'] == def_dask_enabled
+    assert dask_widget.widgets['enabled'].state == def_dask_enabled
 
 
 def test_font_size_widget(qtbot, pref):
@@ -68,6 +93,94 @@ def test_font_size_widget(qtbot, pref):
     font_size_widget._reset_button.click()
     assert get_settings().appearance.font_size == def_font_size
     assert font_size_widget.state == def_font_size
+
+
+@pytest.mark.parametrize(
+    ('enum_setting_name', 'enum_setting_class'),
+    [
+        ('new_labels_dtype', LabelDTypes),
+        ('brush_size_on_mouse_move_modifiers', BrushSizeOnMouseModifiers),
+    ],
+)
+def test_StrEnum_widgets(qtbot, pref, enum_setting_name, enum_setting_class):
+    enum_widget = (
+        pref._stack.currentWidget().widget().widget.widgets[enum_setting_name]
+    )
+    settings = pref._settings
+
+    # check custom widget definition and widget value follows setting
+    assert isinstance(enum_widget, EnumSchemaWidget)
+    assert enum_widget.state == getattr(
+        settings.application, enum_setting_name
+    )
+
+    # check changing setting via widget
+    for idx in range(enum_widget.count()):
+        item_text = enum_widget.itemText(idx)
+        item_data = enum_widget.itemData(idx)
+        enum_widget.setCurrentText(item_text)
+        assert getattr(settings.application, enum_setting_name) == item_data
+        assert enum_widget.state == item_data
+
+    # check changing setting updates widget
+    for enum_value in enum_setting_class:
+        setattr(settings.application, enum_setting_name, enum_value)
+        assert enum_widget.state == enum_value
+
+
+def test_highlight_widget(qtbot, pref):
+    highlight_widget = (
+        pref._stack.widget(1).widget().widget.widgets['highlight']
+    )
+    settings = pref._settings
+
+    # check custom widget definition and widget follows settings values
+    assert isinstance(highlight_widget, HighlightPreviewWidget)
+    assert (
+        highlight_widget.state['highlight_color']
+        == settings.appearance.highlight.highlight_color
+    )
+    assert (
+        highlight_widget.state['highlight_thickness']
+        == settings.appearance.highlight.highlight_thickness
+    )
+
+    # check changing setting via widget
+    new_widget_values = {
+        'highlight_thickness': 5,
+        'highlight_color': [0.6, 0.6, 1.0, 1.0],
+    }
+    highlight_widget.setValue(new_widget_values)
+    npt.assert_allclose(
+        settings.appearance.highlight.highlight_color,
+        new_widget_values['highlight_color'],
+    )
+    assert (
+        settings.appearance.highlight.highlight_thickness
+        == new_widget_values['highlight_thickness']
+    )
+
+    # check changing setting updates widget
+    new_setting_values = {
+        'highlight_thickness': 1,
+        'highlight_color': [0.5, 0.6, 1.0, 1.0],
+    }
+
+    settings.appearance.highlight.highlight_color = new_setting_values[
+        'highlight_color'
+    ]
+    npt.assert_allclose(
+        highlight_widget.state['highlight_color'],
+        new_setting_values['highlight_color'],
+    )
+
+    settings.appearance.highlight.highlight_thickness = new_setting_values[
+        'highlight_thickness'
+    ]
+    assert (
+        highlight_widget.state['highlight_thickness']
+        == new_setting_values['highlight_thickness']
+    )
 
 
 def test_preferences_dialog_accept(qtbot, pref):
@@ -101,9 +214,21 @@ def test_preferences_dialog_cancel(qtbot, pref):
 
 
 def test_preferences_dialog_restore(qtbot, pref, monkeypatch):
+    theme_widget = pref._stack.widget(1).widget().widget.widgets['theme']
+    highlight_widget = (
+        pref._stack.widget(1).widget().widget.widgets['highlight']
+    )
     assert get_settings().appearance.theme == 'light'
+    assert theme_widget.state == 'light'
+    assert get_settings().appearance.highlight.highlight_thickness == 5
+    assert highlight_widget.state['highlight_thickness'] == 5
+
     monkeypatch.setattr(
         QMessageBox, 'question', lambda *a: QMessageBox.RestoreDefaults
     )
     pref._restore_default_dialog()
+
     assert get_settings().appearance.theme == 'dark'
+    assert theme_widget.state == 'dark'
+    assert get_settings().appearance.highlight.highlight_thickness == 1
+    assert highlight_widget.state['highlight_thickness'] == 1

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -257,7 +257,7 @@ class QtViewer(QSplitter):
         settings = get_settings()
         self._update_dask_cache_settings(settings.application.dask)
 
-        settings.application.events.dask.connect(
+        settings.application.dask.events.connect(
             self._update_dask_cache_settings
         )
 
@@ -313,7 +313,7 @@ class QtViewer(QSplitter):
         if not dask_setting:
             return
         if not isinstance(dask_setting, DaskSettings):
-            dask_setting = dask_setting.value
+            dask_setting = get_settings().application.dask
 
         enabled = dask_setting.enabled
         size = dask_setting.cache

--- a/napari/_qt/widgets/qt_highlight_preview.py
+++ b/napari/_qt/widgets/qt_highlight_preview.py
@@ -459,6 +459,8 @@ class QtHighlightPreviewWidget(QWidget):
             color_value = color_value.tolist()
         if color_value == self._color_value:
             return
+        if color_value == '':
+            return
         self._color_value = color_value
         self._value['highlight_color'] = self._color_value
         self.valueChanged.emit(self._value)
@@ -496,8 +498,8 @@ class QtHighlightPreviewWidget(QWidget):
         value : dict
             Highlight value (thickness and color).
         """
-        self._update_thickness_value(value['highlight_thickness'])
-        self._update_color_value(value['highlight_color'])
+        self._update_thickness_value(value.get('highlight_thickness', ''))
+        self._update_color_value(value.get('highlight_color', ''))
         self._refresh()
 
     def description(self):

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
 from psutil import virtual_memory
 
@@ -36,13 +36,6 @@ class DaskSettings(EventedModel):
 
 
 class ApplicationSettings(EventedModel):
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        self.dask.events.connect(self._dask_changed)
-
-    def _dask_changed(self) -> None:
-        self.events.dask(value=self.dask)
-
     first_time: bool = Field(
         True,
         title=trans._('First time'),


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/7027

# References and relevant issues

Closes #7020 

# Description

Remove logic that overrides dask settings event handling and update `QtViewer` logic to handle the change and handle nested event model settings changes to update preferences dialog widgets.

As a little bit of context, due to the changes done at #6113 now there is some logic to keep synced the settings and the preference dialog generated widgets. This logic relies on the settings events. With the way dask settings was worki...